### PR TITLE
account for debug mode when digging into marko internals

### DIFF
--- a/src/common/transformer/test/test.server.js
+++ b/src/common/transformer/test/test.server.js
@@ -11,8 +11,9 @@ try {
     Builder = require('marko/compiler/Builder');
 } catch (e) {
     // v4 paths
-    CompileContext = require('marko/dist/compiler/CompileContext');
-    Builder = require('marko/dist/compiler/Builder');
+    const target = require('marko/env').isDebug ? 'src' : 'dist';
+    CompileContext = require(`marko/${target}/compiler/CompileContext`);
+    Builder = require(`marko/${target}/compiler/Builder`);
 }
 
 function getTransformedTemplate(srcString, templatePath) {


### PR DESCRIPTION
In the transform test, the compiler is being pulled from [`marko/compiler`](https://github.com/mlrawlings/ebayui-core/blob/transform-test/src/common/transformer/test/test.server.js#L3), but the `CompileContext` and `Builder` are pulled from [`marko/dist`](https://github.com/mlrawlings/ebayui-core/blob/transform-test/src/common/transformer/test/test.server.js#L14-L15).

The `parseRaw` function is used to create the AST, and this is called from the compiler which is loaded from either `src/` or `dist/` depending on the value of `NODE_ENV`.  It defaults to `src/`.

The `walker` is created from the context which is hard-coded to load from `dist/`.

The walker has a check for [`node instanceof Container`](https://github.com/marko-js/marko/blob/master/src/compiler/Walker.js#L116-L121).

So when the tag body (an `ArrayContainer`) is encounted, this check is returning `false` because this is the `ArrayContainer` from `marko/src/compiler/ast/ArrayContainer` which inherits from `marko/src/compiler/ast/Container` and is not an instance of the `Container` from `marko/dist/compiler/ast/Container`.